### PR TITLE
Home page listing installed sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /Projects/*
 .vagrant/*
 www/*
-!www/index.html
+!www/index.php
 config.custom.yaml

--- a/www/index.html
+++ b/www/index.html
@@ -1,4 +1,0 @@
-<html><body><h1>It works!</h1>
-<p>This is the default web page for this server.</p>
-<p>The web server software is running but no content has been added, yet.</p>
-</body></html>

--- a/www/index.php
+++ b/www/index.php
@@ -1,0 +1,31 @@
+<html>
+	<body>
+		<h1>It works!</h1>
+		<p>This is the default web page for this server.</p>
+		<h2>Installed sites:</h2>
+		<?php
+		$dir = new DirectoryIterator('.');
+		foreach ($dir as $fileinfo)
+		{
+			if ($fileinfo->isDir() && !$fileinfo->isDot())
+			{
+				$subfolders = scandir($fileinfo);
+
+				// Checks if is a joomla site (avoids to show folders like /logs/ )
+				if (in_array("administrator", $subfolders))
+				{
+					?>
+					<a href="<?php echo $fileinfo->getFilename() ?>">
+						<?php echo $fileinfo->getFilename() ?>
+					</a> (<a href="<?php echo $fileinfo->getFilename() . '/administrator/'; ?>">administrator</a>)
+					<br>
+				<?php
+				}
+			}
+		}
+		?>
+		<p>To install new sites check the instructions at <a href="https://github.com/joomlatools/joomla-console#create-sites">https://github.com/joomlatools/joomla-console#create-sites</a></p>
+		<h2>Tools:</h2>
+		<a href="http://phpmyadmin.joomla.dev/">PHPmyAdmin</a>
+	</body>
+</html>


### PR DESCRIPTION
This is just a proof of concept, in case you like it we can make it better.

I'm using more and more the Vagrant box for testing, so I got this idea of having a functional home page that provides me with shortcuts to directly access to the already installed sites. See the preview:

![screen shot 2014-06-05 at 12 10 36](https://cloud.githubusercontent.com/assets/1375475/3186019/6bf0fff4-ec9b-11e3-88c0-fe223d37c771.png)

Again, this is just a proof of concept. if you like we can do it even more cool and with better code (for example adding Bootstrap, showing the Joomla installed version...).

Thanks ^_^

Joomla Vagrant rocks!
