### PR TITLE
Adds link to MailCatcher in Dashboard

### DIFF
--- a/puppet/modules/scripts/files/scripts/dashboard/index.php
+++ b/puppet/modules/scripts/files/scripts/dashboard/index.php
@@ -88,6 +88,7 @@ foreach ($dir as $fileinfo)
             <li role="presentation" class="dropdown-header">Tools</li>
             <li><a href="http://phpmyadmin.joomla.dev/">phpMyAdmin</a></li>
             <li><a href="/phpinfo">phpinfo</a></li>
+            <li><a href="http://joomla.dev:1080/">MailCatcher</a></li>
             <?php if (function_exists('apc_cache_info') && @apc_cache_info('opcode')): ?>
                 <li><a href="/apc">APC dashboard</a></li>
             <?php endif; ?>


### PR DESCRIPTION
I found MailCatcher by chance while checking one presentation about the Vagrant Box, but I didn't know about it. Is really great addition to Vagrant, so with this pull I'm trying to make it people to acknowledge about it's existence:

![screen shot 2015-01-21 at 12 13 41](https://cloud.githubusercontent.com/assets/1375475/5835238/73c8ef36-a166-11e4-915f-73cec44d623c.png)

The link takes to the Mail Catcher:

![screen shot 2015-01-21 at 12 27 48](https://cloud.githubusercontent.com/assets/1375475/5835393/69d84556-a168-11e4-82cb-95b241d327c8.png)
