### PR TITLE
Fix problem with phpmyadmin manifest @ windows

### DIFF
--- a/puppet/modules/phpmyadmin/manifests/init.pp
+++ b/puppet/modules/phpmyadmin/manifests/init.pp
@@ -57,13 +57,8 @@ class phpmyadmin (
   # On some machines the phpmyadmin user might be already installed.
   # We have to drop and re-add this user because of new privileges and password.
   exec{ 'creating-phpmyadmin-controluser':
-    command => "echo \"CREATE USER 'phpmyadmin'@'localhost'\
-      IDENTIFIED BY '${::pma_controluser_password}';\
-      GRANT ALL ON *.* TO 'phpmyadmin'@'localhost';FLUSH PRIVILEGES;\"\
-      | mysql -u root -p'${::pma_mysql_root_password}'",
+    command => "echo \"CREATE USER 'phpmyadmin'@'localhost' IDENTIFIED BY '${::pma_controluser_password}'; GRANT ALL ON *.* TO 'phpmyadmin'@'localhost';FLUSH PRIVILEGES;\" | mysql -u root -p'${::pma_mysql_root_password}'",
     path    => ['/usr/local/bin', '/usr/bin', '/bin'],
-    unless  => "mysql -u root -p'${::pma_mysql_root_password}'\
-      -e 'select * from mysql.user WHERE User=\"phpmyadmin\"' \
-      | grep 'phpmyadmin'"
+    unless  => "mysql -u root -p'${::pma_mysql_root_password}' -e 'select * from mysql.user WHERE User=\"phpmyadmin\"' | grep 'phpmyadmin'"
   }
 }


### PR DESCRIPTION
When hacking the box under windows, there is a problem running vagrant:

    ==> default: warning: Unrecognised escape sequence '\
    ' in file /tmp/vagrant-puppet/modules-fa1fd1809147158956391178e680a4c2/phpmyadmin/manifests/init.pp at line 61
    ==> default: warning: Unrecognised escape sequence '\
    ' in file /tmp/vagrant-puppet/modules-fa1fd1809147158956391178e680a4c2/phpmyadmin/manifests/init.pp at line 63
    ==> default: warning: Unrecognised escape sequence '\
    ' in file /tmp/vagrant-puppet/modules-fa1fd1809147158956391178e680a4c2/phpmyadmin/manifests/init.pp at line 63
    ==> default: warning: Unrecognised escape sequence '\
    ' in file /tmp/vagrant-puppet/modules-fa1fd1809147158956391178e680a4c2/phpmyadmin/manifests/init.pp at line 67    
    ==> default: warning: Unrecognised escape sequence '\
    ' in file /tmp/vagrant-puppet/modules-fa1fd1809147158956391178e680a4c2/phpmyadmin/manifests/init.pp at line 67

And then there are problems running the box (virtual hosts not setup @ apache).

Putting the arguments on single lines, fixes the problem,